### PR TITLE
Athenz Authentication for Pulsar

### DIFF
--- a/src/main/java/net/opentsdb/horizon/alerts/EnvironmentConfig.java
+++ b/src/main/java/net/opentsdb/horizon/alerts/EnvironmentConfig.java
@@ -291,6 +291,22 @@ public class EnvironmentConfig {
 
     private static final String DEFAULT_ENABLE_SNOOZE_TAGS = "false";
 
+    public static final String PULSAR_ATHENZ_TENANT_DOMAIN = "pulsar_athenz_tenant_domain";
+
+    public static final String DEFAULT_PULSAR_ATHENZ_TENANT_DOMAIN = "";
+
+    public static final String PULSAR_ATHENZ_TENANT_SERVICE = "pulsar_athenz_tenant_service";
+
+    public static final String DEFAULT_PULSAR_ATHENZ_TENANT_SERVICE = "";
+
+    public static final String PULSAR_ATHENZ_PROVIDER_DOMAIN = "pulsar_athenz_provider_domain";
+
+    public static final String DEFAULT_PULSAR_ATHENZ_PROVIDER_DOMAIN = "";
+
+    public static final String PULSAR_ATHENZ_KEY_ID = "pulsar_athenz_key_id";
+
+    public static final String DEFAULT_PULSAR_ATHENZ_KEY_ID = "0";
+
     static {
         String file = PROPERTIES_FILE;
         if(IS_LOCAL) {
@@ -521,6 +537,22 @@ public class EnvironmentConfig {
 
     public String getPulsarTopicName() {
         return propertiesFile.getProperty(PULSAR_TOPIC_NAME, DEFAULT_PULSAR_TOPIC_NAME);
+    }
+
+    public String getPulsarAthenzTenantDomain() {
+        return propertiesFile.getProperty(PULSAR_ATHENZ_TENANT_DOMAIN, DEFAULT_PULSAR_ATHENZ_TENANT_DOMAIN);
+    }
+
+    public String getPulsarAthenzTenantService() {
+        return propertiesFile.getProperty(PULSAR_ATHENZ_TENANT_SERVICE, DEFAULT_PULSAR_ATHENZ_TENANT_SERVICE);
+    }
+
+    public String getPulsarAthenzProviderDomain() {
+        return propertiesFile.getProperty(PULSAR_ATHENZ_PROVIDER_DOMAIN, DEFAULT_PULSAR_ATHENZ_PROVIDER_DOMAIN);
+    }
+
+    public String getPulsarAthenzKeyId() {
+        return propertiesFile.getProperty(PULSAR_ATHENZ_KEY_ID, DEFAULT_PULSAR_ATHENZ_KEY_ID);
     }
 
     public String getStatusWriteSink() {


### PR DESCRIPTION
## Issue
Athenz authentication for Pulsar not implemented

## Modification
* Add necessary settings to EnvironmentConfig
* Set Authentication when initializing Pulsar Client

## Usage
When performing Athenz authentication, please set as follows
```
athens_key_file=<key_uri>
pulsar_athenz_enabled=true
pulsar_athenz_tenant_domain=<domain>
pulsar_athenz_tenant_service=<service>
pulsar_athenz_provider_domain=<provider_domain>
pulsar_athenz_key_id=<id>
```

## consultation
* Should I also add the path of ztsUrl or athenz.conf to the settings?
  * The Athenz authentication header (principal or role header) has a default value, so user should specify it in the JVM option only if user want to overwrite it.
  * However, ztsUrl is required and has no default value.
  * I made a policy to specify it in the JVM option (-D athenz.athenz_conf), but is it better to specify it in the setting value file?