### PR TITLE
remove log4j-1 dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ allprojects {
     }
 
     dependencies {
-        implementation ('net.opentsdb:opentsdb-core:3.0.90-SNAPSHOT') 
+        implementation ('net.opentsdb:opentsdb-core:3.0.90-SNAPSHOT')
         implementation 'net.opentsdb:opentsdb-common:3.0.90-SNAPSHOT'
         implementation 'org.projectlombok:lombok:1.18.8'
         compileOnly 'com.intellij:annotations:12.0'
@@ -59,6 +59,10 @@ allprojects {
         testImplementation 'org.testng:testng:6.10'
 
         archives('org.apache.maven.wagon:wagon-ssh-external:3.3.2')
+    }
+
+    configurations.implementation {
+        exclude group: 'log4j', module: 'log4j'
     }
 }
 
@@ -87,7 +91,6 @@ dependencies {
     implementation 'org.apache.pulsar:pulsar-client-auth-athenz:2.7.2'
     implementation('org.apache.kafka:kafka_2.9.2:0.8.2.1') {
         exclude group: 'org.apache.zookeeper', module: 'zookeeper'
-        exclude group: 'log4j', module: 'log4j'
     }
     implementation 'org.apache.commons:commons-email:1.4'
     implementation 'org.jsoup:jsoup:1.8.3'


### PR DESCRIPTION
### issue
This component has a dependency on log4j Series 1, but log4j-1 is EOL and vulnerable

https://blogs.apache.org/foundation/entry/apache_logging_services_project_announces
https://mvnrepository.com/artifact/log4j/log4j

### Fix
remove log4j-1 dependency.
Library exclusions were set for the entire project due to indirect dependencies in multiple projects.
