### PR TITLE
add weblink url to email template

### DIFF
--- a/notification/src/main/java/net/opentsdb/horizon/alerting/corona/processor/emitter/email/formatter/AbstractEmailFormatter.java
+++ b/notification/src/main/java/net/opentsdb/horizon/alerting/corona/processor/emitter/email/formatter/AbstractEmailFormatter.java
@@ -58,6 +58,12 @@ public abstract class AbstractEmailFormatter<
 
         private final Map<String, Object> params = new HashMap<>();
 
+        private Parameters setWebuiLink(final String webuiLink)
+        {
+            params.put("webuiLink", webuiLink);
+            return this;
+        }
+
         private Parameters setDetailsLink(final String detailsLink)
         {
             params.put("detailsLink", detailsLink);
@@ -252,6 +258,9 @@ public abstract class AbstractEmailFormatter<
                 view.getAllViews().get(0).getTimestampMs();
 
         final Parameters params = new Parameters()
+                .setWebuiLink(
+                        Views.get().horizonUrl()
+                )
                 .setDetailsLink(
                         Views.get().alertSplunkUrl(alertId, sampleAlertTimestampMs)
                 )

--- a/notification/src/main/java/net/opentsdb/horizon/alerting/corona/processor/emitter/view/Views.java
+++ b/notification/src/main/java/net/opentsdb/horizon/alerting/corona/processor/emitter/view/Views.java
@@ -200,6 +200,10 @@ public class Views {
 
     /* ------------ Methods ------------ */
 
+    public String horizonUrl() {
+        return horizonUrl;
+    }
+
     public String alertEditUrl(final long alertId)
     {
         return horizonUrl + "/a/" + alertId + "/edit";

--- a/notification/src/main/resources/templates/email-event-alert.html
+++ b/notification/src/main/resources/templates/email-event-alert.html
@@ -118,7 +118,7 @@
     <table cellpadding="0" cellspacing="0" width="640px" class="footer">
         <tr>
             <td valign="top">
-                This is a generated email from <a href="">OpenTSDB</a>
+                This is a generated email from <a href="{{ webuiLink }}">OpenTSDB</a>
             </td>
         </tr>
     </table>

--- a/notification/src/main/resources/templates/email-health-check-alert.html
+++ b/notification/src/main/resources/templates/email-health-check-alert.html
@@ -113,7 +113,7 @@
     <table cellpadding="0" cellspacing="0" width="640px" class="footer">
         <tr>
             <td valign="top">
-                This is a generated email from <a href="">OpenTSDB</a>
+                This is a generated email from <a href="{{ webuiLink }}">OpenTSDB</a>
             </td>
         </tr>
     </table>

--- a/notification/src/main/resources/templates/email-period-over-period-alert.html
+++ b/notification/src/main/resources/templates/email-period-over-period-alert.html
@@ -104,7 +104,7 @@
     <table cellpadding="0" cellspacing="0" width="640px" class="footer">
         <tr>
             <td valign="top">
-                This is a generated email from <a href="">OpenTSDB</a>
+                This is a generated email from <a href="{{ webuiLink }}">OpenTSDB</a>
             </td>
         </tr>
     </table>

--- a/notification/src/main/resources/templates/email-single-metric-alert.html
+++ b/notification/src/main/resources/templates/email-single-metric-alert.html
@@ -104,7 +104,7 @@
     <table cellpadding="0" cellspacing="0" width="640px" class="footer">
         <tr>
             <td valign="top">
-                This is a generated email from <a href="">OpenTSDB</a>
+                This is a generated email from <a href="{{ webuiLink }}">OpenTSDB</a>
             </td>
         </tr>
     </table>


### PR DESCRIPTION
### issue
In Email notifications, the link in the Footer section is not working.
```
This is a generated email from OpenTSDB
```
This is because the href attribute has no value set.

### Fix
The href attribute of the template is set to the "horizonurl" variable that the Views class has.