### PR TITLE
Fix garbled slack notification text

### DIFF
--- a/notification/src/main/java/net/opentsdb/horizon/alerting/corona/processor/emitter/slack/client/impl/SlackClientImpl.java
+++ b/notification/src/main/java/net/opentsdb/horizon/alerting/corona/processor/emitter/slack/client/impl/SlackClientImpl.java
@@ -78,8 +78,8 @@ public final class SlackClientImpl implements SlackClient {
         try {
             final String jsonBody = MAPPER.writeValueAsString(request);
             System.out.println(jsonBody);
-            httpReq.setEntity(new StringEntity(jsonBody));
-        } catch (JsonProcessingException | UnsupportedEncodingException e) {
+            httpReq.setEntity(new StringEntity(jsonBody, "UTF-8"));
+        } catch (JsonProcessingException e) {
             throw new SlackException("serialization failed", e);
         }
 


### PR DESCRIPTION
### issue
Slack notifications garble multibyte characters.

### Fix
Explicitly specified UTF-8 when creating a request body to Slack